### PR TITLE
Updated paystack-payment-processor to get required data

### DIFF
--- a/packages/plugin/src/services/paystack-payment-processor.ts
+++ b/packages/plugin/src/services/paystack-payment-processor.ts
@@ -96,8 +96,8 @@ class PaystackPaymentProcessor extends AbstractPaymentProvider {
       );
     }
 
-    const { context, amount, currency_code } = initiatePaymentData;
-    const { email, session_id } = context;
+    const { context, amount, currency_code, data } = initiatePaymentData;
+    const { email, session_id } = data;
 
     const validatedCurrencyCode = formatCurrencyCode(currency_code);
 
@@ -180,7 +180,7 @@ class PaystackPaymentProcessor extends AbstractPaymentProvider {
     }
 
     try {
-      const { paystackTxRef } = paymentSessionData;
+      const { paystackTxRef } = paymentSessionData.data;
 
       const { status, data } = await this.paystack.transaction.verify({
         reference: paystackTxRef,


### PR DESCRIPTION
Updated the error of not finding the accesscode, reference code, and authorization url in the paymentSessionData object returned in medusa v2